### PR TITLE
unzip missing in setup script + geckodriver has not been loaded

### DIFF
--- a/scripts/completedns-get-ns-history
+++ b/scripts/completedns-get-ns-history
@@ -50,7 +50,7 @@ options.set_preference("network.http.redirection-limit", 4)
 options.set_preference("general.useragent.override", "Safari: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.3 (KHTML, like Gecko) Version/11.1 Safari/605.1.3")
 
 # prevent creation of geckodriver.log
-service = Service(log_output="/dev/null")
+service = Service(log_output="/dev/null", executable_path="/usr/local/bin/geckodriver")
 driver = webdriver.Firefox(options=options, service=service)
 
 # 10 seconds timeout

--- a/scripts/dnslytics-get-rootdomains
+++ b/scripts/dnslytics-get-rootdomains
@@ -31,7 +31,7 @@ options.add_argument('--ignore-certificate-errors')
 options.set_preference("general.useragent.override", "Safari: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.3 (KHTML, like Gecko) Version/11.1 Safari/605.1.3")
 
 # prevent creation of geckodriver.log
-service = Service(log_output="/dev/null")
+service = Service(log_output="/dev/null", executable_path="/usr/local/bin/geckodriver")
 driver = webdriver.Firefox(options=options, service=service)
 
 # 10 seconds timeout

--- a/scripts/google-get-rootdomains
+++ b/scripts/google-get-rootdomains
@@ -33,7 +33,7 @@ options.add_argument('--ignore-certificate-errors')
 options.set_preference("general.useragent.override", "Safari: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.3 (KHTML, like Gecko) Version/11.1 Safari/605.1.3")
 
 # prevent creation of geckodriver.log
-service = Service(log_output="/dev/null")
+service = Service(log_output="/dev/null", executable_path="/usr/local/bin/geckodriver")
 driver = webdriver.Firefox(options=options, service=service)
 
 # 10 seconds default wait for element to be clickable

--- a/scripts/grepapp-get-users
+++ b/scripts/grepapp-get-users
@@ -21,7 +21,7 @@ options.add_argument("--ignore-ssl-errors=yes")
 options.add_argument('--ignore-certificate-errors')
 options.set_preference("network.http.redirection-limit", 4)
 options.add_argument("--headless")
-service = Service(log_output="/dev/null")
+service = Service(log_output="/dev/null", executable_path="/usr/local/bin/geckodriver")
 driver = webdriver.Firefox(options=options, service=service)
 driver.set_page_load_timeout(15)
 

--- a/scripts/hackertarget-get-rootdomains
+++ b/scripts/hackertarget-get-rootdomains
@@ -28,7 +28,7 @@ options.add_argument('--ignore-certificate-errors')
 options.set_preference("general.useragent.override", "Safari: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.3 (KHTML, like Gecko) Version/11.1 Safari/605.1.3")
 
 # prevent creation of geckodriver.log
-service = Service(log_output="/dev/null")
+service = Service(log_output="/dev/null", executable_path="/usr/local/bin/geckodriver")
 driver = webdriver.Firefox(options=options, service=service)
 
 # 6 seconds timeout

--- a/scripts/handelsregister-get-company-names
+++ b/scripts/handelsregister-get-company-names
@@ -28,7 +28,7 @@ options.add_argument('--ignore-certificate-errors')
 options.set_preference("general.useragent.override", "Safari: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.3 (KHTML, like Gecko) Version/11.1 Safari/605.1.3")
 
 # prevent creation of geckodriver.log
-service = Service(log_output="/dev/null")
+service = Service(log_output="/dev/null", executable_path="/usr/local/bin/geckodriver")
 driver = webdriver.Firefox(options=options, service=service)
 
 # 10 seconds default wait for element to be clickable

--- a/scripts/northdata-get-company-names
+++ b/scripts/northdata-get-company-names
@@ -22,7 +22,7 @@ options.add_argument("--ignore-ssl-errors=yes")
 options.add_argument('--ignore-certificate-errors')
 options.set_preference("network.http.redirection-limit", 4)
 options.add_argument("--headless")
-service = Service(log_output="/dev/null")
+service = Service(log_output="/dev/null", executable_path="/usr/local/bin/geckodriver")
 driver = webdriver.Firefox(options=options, service=service)
 driver.set_page_load_timeout(45)
 

--- a/scripts/skymem-get-mails
+++ b/scripts/skymem-get-mails
@@ -19,7 +19,7 @@ options.add_argument("--ignore-ssl-errors=yes")
 options.add_argument('--ignore-certificate-errors')
 options.set_preference("network.http.redirection-limit", 4)
 options.add_argument("--headless")
-service = Service(log_output="/dev/null")
+service = Service(log_output="/dev/null", executable_path="/usr/local/bin/geckodriver")
 driver = webdriver.Firefox(options=options, service=service)
 driver.set_page_load_timeout(20)
 

--- a/scripts/sourcegraph-get-users
+++ b/scripts/sourcegraph-get-users
@@ -28,7 +28,7 @@ options.add_argument('--ignore-certificate-errors')
 options.set_preference("general.useragent.override", "Safari: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.3 (KHTML, like Gecko) Version/11.1 Safari/605.1.3")
 
 # prevent creation of geckodriver.log
-service = Service(log_output="/dev/null")
+service = Service(log_output="/dev/null", executable_path="/usr/local/bin/geckodriver")
 driver = webdriver.Firefox(options=options, service=service)
 
 # 10 seconds timeout

--- a/scripts/spyonweb-get-rootdomains
+++ b/scripts/spyonweb-get-rootdomains
@@ -32,7 +32,7 @@ options.add_argument('--ignore-certificate-errors')
 options.set_preference("general.useragent.override", "Safari: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.3 (KHTML, like Gecko) Version/11.1 Safari/605.1.3")
 
 # prevent creation of geckodriver.log
-service = Service(log_output="/dev/null")
+service = Service(log_output="/dev/null", executable_path="/usr/local/bin/geckodriver")
 driver = webdriver.Firefox(options=options, service=service)
 
 # 10 seconds timeout

--- a/scripts/tmdb-get-company-names
+++ b/scripts/tmdb-get-company-names
@@ -27,7 +27,7 @@ options.add_argument('--ignore-certificate-errors')
 options.set_preference("general.useragent.override", "Safari: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.3 (KHTML, like Gecko) Version/11.1 Safari/605.1.3")
 
 # prevent creation of geckodriver.log
-service = Service(log_output="/dev/null")
+service = Service(log_output="/dev/null", executable_path="/usr/local/bin/geckodriver")
 driver = webdriver.Firefox(options=options, service=service)
 
 # 10 seconds default wait for element to be clickable

--- a/scripts/viewdns-get-rootdomains-ip-ns
+++ b/scripts/viewdns-get-rootdomains-ip-ns
@@ -32,7 +32,7 @@ options.add_argument('--ignore-certificate-errors')
 options.set_preference("general.useragent.override", "Safari: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.3 (KHTML, like Gecko) Version/11.1 Safari/605.1.3")
 
 # prevent creation of geckodriver.log
-service = Service(log_output="/dev/null")
+service = Service(log_output="/dev/null", executable_path="/usr/local/bin/geckodriver")
 driver = webdriver.Firefox(options=options, service=service)
 
 # 6 seconds timeout

--- a/scripts/viewdns-get-rootdomains-whois
+++ b/scripts/viewdns-get-rootdomains-whois
@@ -29,7 +29,7 @@ options.add_argument('--ignore-certificate-errors')
 options.set_preference("general.useragent.override", "Safari: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.3 (KHTML, like Gecko) Version/11.1 Safari/605.1.3")
 
 # prevent creation of geckodriver.log
-service = Service(log_output="/dev/null")
+service = Service(log_output="/dev/null", executable_path="/usr/local/bin/geckodriver")
 driver = webdriver.Firefox(options=options, service=service)
 
 # 6 seconds timeout

--- a/scripts/zoomeye-get-rootdomains
+++ b/scripts/zoomeye-get-rootdomains
@@ -27,7 +27,7 @@ options.add_argument('--ignore-certificate-errors')
 options.set_preference("general.useragent.override", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.190 Safari/537.36")
 
 # prevent creation of geckodriver.log
-service = Service(log_output="/dev/null")
+service = Service(log_output="/dev/null", executable_path="/usr/local/bin/geckodriver")
 driver = webdriver.Firefox(options=options, service=service)
 
 # seconds timeout

--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,7 @@ userName=$(echo $USER)
 
 echo ""
 echo "### APT Install"
-apt install -y dnsrecon git wget python3 python3-pip whois curl nmap libimage-exiftool-perl jq dnstwist
+apt install -y dnsrecon git wget python3 python3-pip whois curl nmap libimage-exiftool-perl jq dnstwist unzip
 
 echo ""
 echo "### Install Golang tools."


### PR DESCRIPTION
Tested on an clear EC2 Linux:

1. Setup.sh - unzip missing
Script broke up after it could not unzip the golang zip. Added unzip to the setup.sh script to solve this issue

2. geckodriver
Had trouble with the gecko driver. Python Scripts does not load the geckodriver. Specifying the geckodriver in the Service with the option executable_path does solve this issue.

Hope this helps. If not, just delete this Pull Request :)